### PR TITLE
Added multi-user support in front-matter

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -105,15 +105,19 @@ module.exports = function(locals) {
         });
       }
       else if (gh.type === 'get_repos') {
-        github.repos.getFromUser({
-          user : gh.user
-        }, function(err, res) {
-          if (res) {
-            fs.writeFileSync(path, JSON.stringify(res));
-          }
-          else {
-            _self.log.w("generate github " + path + " failed");
-          }
+        gh.user.forEach(function(user) {
+            var cachePath = path.substring(0, path.lastIndexOf("/") + 1) + user + ".json";
+
+            github.repos.getFromUser({
+                user : user
+            }, function(err, res) {
+                if (res) {
+                    fs.writeFileSync(cachePath, JSON.stringify(res));
+                }
+                else {
+                    _self.log.w("generate github " + path + " for " + user + " failed");
+                }
+            });
         });
       }
     }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -139,13 +139,14 @@ function gh_repos(options) {
 
   // gh.setToken(this.config.github.token);
   var repos = [];
-  var cache = (_self.gh_read_cache(this.page));
-  if (cache) {
-    repos = JSON.parse(cache);
-  }
-  else {
-    repos = gh.reqSync(url);
-    this.gh_write_cache(this.gh_cache_dir(this.page, JSON.stringify(repos)));
+  var pagePath = this.page.path;
+  var cachePath = pagePath.substring(0, pagePath.lastIndexOf("/") + 1) + user + ".json";
+  var path = pathFn.join(this.config.github.cache_dir, cachePath);
+  if (fs.existsSync(path)) {
+      repos = JSON.parse(fs.readFileSync(path));
+  } else {
+      repos = gh.reqSync(url);
+      this.gh_write_cache(path, JSON.stringify(repos));
   }
   console.log('%s has %d repos', user, repos.length);
   var config_repos = _self.config.github.repos;


### PR DESCRIPTION
Came across with a scenario where multiple users' repos needed to be cached in the same page, so I added the feature. Now the front-matter may look like this: 
```
---
gh:
  user:
    - someuser
    - someotheruser
  type: get_repos
layout: xxx
title: xxxx
date: xxxx-xx-xx
---
```
Response results will be cached separately as `[username].json` in the cache directory. Also modified `gh_repos` so that single user's cache can be retrieved by calling `gh_repos([username])`.

Note that the scenario only applies for `gh.type` as `get_repos`. Want your opinion on this!